### PR TITLE
Added clarifying note about Nodesmith service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The three parts to this tutorial are:
 
 - Install Prereqs https://docs.aion.network/docs/maven-and-aion4j-installation#section-windows
 - Install Aiwa Chrome extension
-- Obtain an Endpoint from nodesmith.io. Should look something like this: https://api.nodesmith.io/v1/aion/mainnet/jsonrpc?apiKey=333be7bc8dcf4068807ba4c3c5209942
+- Obtain an Endpoint from [https://dashboard.nodesmith.io](https://dashboard.nodesmith.io). Should look something like this: https://api.nodesmith.io/v1/aion/mainnet/jsonrpc?apiKey=333be7bc8dcf4068807ba4c3c5209942.  Please note, you must obtain a key from the production Nodesmith service (as opposed to the beta service hosted at https://beta.nodesmith.io).  Only the production service has avmtestnet support.
 - replace mainnet with avmtestnet in the nodesmith endpoint URL to connect to the AVM testnet. 
 - Connect Aiwa to the AVM network, by selecting Custom [network], and input your nodesmith endpoint, with Port 443
 - Get AVM testnet AION from https://faucets.blockxlabs.com/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The three parts to this tutorial are:
 
 - Install Prereqs https://docs.aion.network/docs/maven-and-aion4j-installation#section-windows
 - Install Aiwa Chrome extension
-- Obtain an Endpoint from [https://dashboard.nodesmith.io](https://dashboard.nodesmith.io). Should look something like this: https://api.nodesmith.io/v1/aion/mainnet/jsonrpc?apiKey=333be7bc8dcf4068807ba4c3c5209942.  Please note, you must obtain a key from the production Nodesmith service (as opposed to the beta service hosted at https://beta.nodesmith.io).  Only the production service has avmtestnet support.
+- Obtain an Endpoint from [https://dashboard.nodesmith.io](https://dashboard.nodesmith.io). Should look something like this: https://api.nodesmith.io/v1/aion/mainnet/jsonrpc?apiKey=333be7bc8dcf4068807ba4c3c5209942.  **Important**, you must obtain a key from the production Nodesmith service (as opposed to the beta service hosted at https://beta.dashboard.nodesmith.io).  Only the production service has avmtestnet support currently.
 - replace mainnet with avmtestnet in the nodesmith endpoint URL to connect to the AVM testnet. 
 - Connect Aiwa to the AVM network, by selecting Custom [network], and input your nodesmith endpoint, with Port 443
 - Get AVM testnet AION from https://faucets.blockxlabs.com/


### PR DESCRIPTION
Hey there, great instruction set! 

I've added a line that clarifies that you must use the production site of Nodesmith as opposed to the beta version of the service.  A user had reached out to me and had ran into this issue.  Our beta site doesn't yet have the avmtestnet support, but our production site does.  

Thanks!